### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ make docs
 
 [build-status-image]: https://secure.travis-ci.org/arve0/leicascanningtemplate.png?branch=master
 [travis]: http://travis-ci.org/arve0/leicascanningtemplate?branch=master
-[pypi-version]: https://pypip.in/version/leicascanningtemplate/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/leicascanningtemplate.svg
 [pypi]: https://pypi.python.org/pypi/leicascanningtemplate


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20leicascanningtemplate))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `leicascanningtemplate`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.